### PR TITLE
Add golangcilint and task runner

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,6 +5,14 @@ on:
     tags:
       - '*'
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.48.0
+
   build:
     name: Build on golang ${{ matrix.go_version }} and ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,73 @@
+run:
+  tests: true
+
+issues:
+  max-same-issues: 0
+
+linters-settings:
+  lll:
+    line-length: 130
+
+linters:
+  disable-all: true
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - deadcode
+    - depguard
+    - durationcheck
+    - errcheck
+    - errchkjson
+    - errname
+    - execinquery
+    - exhaustive
+    - exhaustruct
+    - exportloopref
+    - forbidigo
+    - gci
+    - goconst
+    - gocritic
+    - gocyclo
+    - godot
+    - godox
+    - gofmt
+    - gofumpt
+    - goheader
+    - goimports
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - importas
+    - ineffassign
+    - nilnil
+    - lll
+    - makezero
+    - misspell
+    - nakedret
+    - nilerr
+    - nestif
+    - noctx
+    - nolintlint
+    - nosprintfhostport
+    - prealloc
+    - predeclared
+    - revive
+    - staticcheck
+    - stylecheck
+    - tagliatelle
+    - tenv
+    - testpackage
+    - thelper
+    - tparallel
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - usestdlibvars
+    - varcheck
+    - whitespace

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,54 @@
+# https://taskfile.dev
+
+version: '3'
+
+silent: true
+
+vars:
+  GO_MODULE: github.com/kazhuravlev/options-gen
+  GO_FILES:
+    sh: find . -type f -name '*.go' -not -path "./.gocache/*" -not -path "./.go/*" -not -path "_generated.go" | tr "\n" " "
+
+tasks:
+  default:
+    cmds:
+      - task: tidy
+      - task: fmt
+      - task: lint
+      - task: install
+      - task: tests
+      - task: examples:update
+
+  tidy:
+    - echo "- Tidy"
+    - go mod tidy
+
+  fmt:
+    - echo "- Format"
+    - go fmt ./...
+
+  lint:
+    cmds:
+      - echo "- Lint"
+      - golangci-lint run --fix ./...
+
+  install:
+    cmds:
+      - echo "- Install"
+      - go install ./cmd/options-gen
+
+  tests:
+    cmds:
+      - echo "- Tests"
+      - go test -race ./...
+
+  examples:update:
+    cmds:
+      - echo "- Update examples"
+      - cmd: go generate ./...
+      - task: examples:update:library
+
+  examples:update:library:
+    dir: examples/library
+    cmds:
+      - go run main.go

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -6,8 +6,8 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"log"
+	"os"
 	"path"
 	"reflect"
 	"strings"
@@ -157,7 +157,7 @@ func parseTag(tag *ast.BasicLit, fieldName string) TagOption {
 // GetFileImports read the file and parse the imports section. Return all found
 // imports with aliases.
 func GetFileImports(filePath string) ([]string, error) {
-	source, err := ioutil.ReadFile(filePath)
+	source, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read file %q", filePath)
 	}

--- a/options-gen/cmd.go
+++ b/options-gen/cmd.go
@@ -1,7 +1,7 @@
 package optionsgen
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/kazhuravlev/options-gen/internal/generator"
 	"github.com/pkg/errors"
@@ -24,7 +24,7 @@ func Run(inFilename, outFilename, structName, packageName string) error {
 	}
 
 	const perm = 0o644
-	if err := ioutil.WriteFile(outFilename, res, perm); err != nil {
+	if err := os.WriteFile(outFilename, res, perm); err != nil {
 		return errors.Wrap(err, "cannot write result")
 	}
 

--- a/options-gen/cmd_test.go
+++ b/options-gen/cmd_test.go
@@ -1,7 +1,7 @@
 package optionsgen_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -19,7 +19,7 @@ func TestRun(t *testing.T) {
 		var testDirs []string
 		{
 			const testdataDir = "./testdata"
-			fileInfos, err := ioutil.ReadDir(testdataDir)
+			fileInfos, err := os.ReadDir(testdataDir)
 			require.NoError(t, err)
 
 			for _, file := range fileInfos {
@@ -66,10 +66,10 @@ func TestRun(t *testing.T) {
 func helpEqualFiles(t *testing.T, filename1, filename2 string) {
 	t.Helper()
 
-	f1Bytes, err := ioutil.ReadFile(filename1)
+	f1Bytes, err := os.ReadFile(filename1)
 	require.NoError(t, err)
 
-	f2Bytes, err := ioutil.ReadFile(filename2)
+	f2Bytes, err := os.ReadFile(filename2)
 	require.NoError(t, err)
 
 	assert.Equal(t, string(f1Bytes), string(f2Bytes))


### PR DESCRIPTION
Sorry, I'm tired of manual checks.

```
▶ task                
- Tidy
- Format
- Lint
- Install
- Tests
?       github.com/kazhuravlev/options-gen/cmd/options-gen      [no test files]
?       github.com/kazhuravlev/options-gen/examples/cli [no test files]
?       github.com/kazhuravlev/options-gen/examples/library     [no test files]
?       github.com/kazhuravlev/options-gen/examples/library/sub-package [no test files]
ok      github.com/kazhuravlev/options-gen/internal/generator   0.162s
ok      github.com/kazhuravlev/options-gen/options-gen  0.351s
ok      github.com/kazhuravlev/options-gen/pkg/validator        (cached)
- Update examples
```