### PR TITLE
Rename flag that allows to apply option

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ it will have the following arguments:
 - `out-prefix` - add prefix to the generated file. Useful when you have multiple Options structs in the same package.
 
   Default: empty string
-- `out-option-type-name` - name for the option type (function alias).
-  If not specified, the "Opt[StructName]Setter" template is used.
+- `out-setter-name` - name for the option setter type (function alias).
+  If not specified, the `Opt[StructName]Setter` template is used.
 
   Default: `Opt[StructName]Setter`
 

--- a/cmd/options-gen/main.go
+++ b/cmd/options-gen/main.go
@@ -23,7 +23,7 @@ func main() {
 		withIsset             bool
 		allVariadic           bool
 		constructorTypeRender optionsgen.ConstructorTypeRender
-		outOptionTypeName     string
+		outSetterName         string
 	)
 
 	envGoFile := os.Getenv("GOFILE")
@@ -66,9 +66,9 @@ func main() {
 			string(optionsgen.ConstructorPrivateRender),
 			string(optionsgen.ConstructorNoRender),
 		}, ", ")+".")
-	flag.StringVar(&outOptionTypeName,
-		"out-option-type-name", "",
-		"name for the option type (function alias). If not specified, the 'Opt[StructName]Setter' template is used.")
+	flag.StringVar(&outSetterName,
+		"out-setter-name", "",
+		"name for the option setter type (function alias). If not specified, the 'Opt[StructName]Setter' template is used.")
 	flag.Parse()
 
 	if isEmpty(inFilename, outFilename, outPackageName, optionsStructName, defaultsFrom) {
@@ -106,7 +106,7 @@ func main() {
 		withIsset,
 		allVariadic,
 		constructorTypeRender,
-		outOptionTypeName,
+		outSetterName,
 	)
 	if errRun != nil {
 		//nolint:forbidigo

--- a/pkg/errors/validation_errors.go
+++ b/pkg/errors/validation_errors.go
@@ -11,7 +11,7 @@ type validationError struct {
 	err       error
 }
 
-func NewValidationError(fieldName string, err error) *validationError { //nolint:revive
+func NewValidationError(fieldName string, err error) *validationError { //nolint:revive,nolintlint
 	if err == nil {
 		return nil
 	}
@@ -49,7 +49,7 @@ func (e ValidationErrors) Error() string {
 	return buf.String()
 }
 
-func (e ValidationErrors) Errors() []validationError { //nolint:revive
+func (e ValidationErrors) Errors() []validationError { //nolint:revive,nolintlint
 	errs := make([]validationError, len(e))
 	copy(errs, e)
 


### PR DESCRIPTION
Change the name of the flag. This is because the original name mention the Option Name, but actually this is option setter name. It looks more precisely. 